### PR TITLE
Add GitHub Actions release workflow (two-step, on tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,21 @@ jobs:
       - run: cargo test
       - run: cargo publish --dry-run
 
-  publish:
-    name: Publish
+  draft-release:
+    name: Create Draft Release
     runs-on: ubuntu-latest
     needs: verify
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" --draft --generate-notes
+
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: draft-release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -37,13 +48,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  github-release:
-    name: GitHub Release
+  finalize-release:
+    name: Finalize Release
     runs-on: ubuntu-latest
     needs: publish
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Create GitHub Release
+      - name: Mark release as latest
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --generate-notes
+        run: gh release edit "${{ github.ref_name }}" --draft=false --latest


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` triggered on `v*` tags
- Three sequential jobs: verify (full CI + dry-run publish) → publish (crates.io) → github-release (auto-generated notes)
- All actions pinned to commit SHAs, `permissions: contents: write` for release creation
- Requires `CARGO_REGISTRY_TOKEN` repository secret

Closes #5

## Test plan
- [x] Workflow only triggers on `v*` tags
- [x] Build/test must pass before publish step runs
- [x] `cargo publish --dry-run` included in verify step
- [ ] Full release flow (tested on first real tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)