### PR TITLE
Add cargo-deny for dependency auditing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
 
+  deny:
+    name: Deny (advisories + licenses + bans + sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: EmbarkStudios/cargo-deny-action@44db170f6a7d12a6e90340e9e0fca1f650d34b14 # v2.0.15
+
   build:
     name: Build (${{ matrix.os }}, ${{ matrix.rust }})
     runs-on: ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,24 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "OpenSSL",
+    "CDLA-Permissive-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary
- Add `deny.toml` with checks for advisories, licenses, bans, and sources
- Add `deny` job to CI workflow using `EmbarkStudios/cargo-deny-action` (pinned to SHA)
- Allowed licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, Unicode-3.0, OpenSSL, CDLA-Permissive-2.0, and others

Closes #7

## Test plan
- [x] `cargo deny check` passes locally
- [x] CI runs dependency audit on every PR
- [x] Known vulnerabilities would fail the build
- [x] `deny.toml` committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)