### PR TITLE
Implement CloudBackend control commands (PUT /v1/devices/control)

### DIFF
--- a/src/backend/cloud.rs
+++ b/src/backend/cloud.rs
@@ -97,6 +97,9 @@ impl CloudBackend {
     }
 
     /// Send a control command to a device via `PUT /v1/devices/control`.
+    ///
+    /// Parses the response body for API-level errors (HTTP 200 with
+    /// `code != 200` in the JSON envelope).
     async fn send_control(
         &self,
         id: &DeviceId,
@@ -126,7 +129,17 @@ impl CloudBackend {
             .send()
             .await?;
 
-        self.check_response(response).await?;
+        let response = self.check_response(response).await?;
+
+        // Check API-level error code in response body.
+        let body: V1ControlResponse = response.json().await?;
+        if body.code != 200 {
+            return Err(GoveeError::Api {
+                code: body.code,
+                message: body.message,
+            });
+        }
+
         debug!(device = %id, cmd = cmd_name, "sent control command");
         Ok(())
     }
@@ -257,6 +270,13 @@ fn build_state_from_properties(properties: Vec<serde_json::Value>) -> Result<Dev
     DeviceState::new(on, brightness, color, color_temp, !online)
 }
 
+/// Response envelope from `PUT /v1/devices/control`.
+#[derive(serde::Deserialize)]
+struct V1ControlResponse {
+    code: u16,
+    message: String,
+}
+
 /// Parse the `Retry-After` header value as seconds.
 fn parse_retry_after(response: &reqwest::Response) -> u64 {
     response
@@ -374,7 +394,16 @@ impl GoveeBackend for CloudBackend {
         .await
     }
 
+    /// Set color temperature in Kelvin.
+    ///
+    /// No device-specific range validation — the Govee API rejects
+    /// unsupported values. We only reject `0` as physically meaningless.
     async fn set_color_temp(&self, id: &DeviceId, kelvin: u32) -> Result<()> {
+        if kelvin == 0 {
+            return Err(GoveeError::InvalidConfig(
+                "color temperature must be > 0K".into(),
+            ));
+        }
         self.send_control(id, "colorTem", serde_json::json!(kelvin))
             .await
     }

--- a/tests/cloud_mock.rs
+++ b/tests/cloud_mock.rs
@@ -332,6 +332,8 @@ async fn get_state_rate_limited() {
 
 // --- control command tests ---
 
+const CONTROL_SUCCESS: &str = r#"{"code": 200, "message": "Success"}"#;
+
 #[tokio::test]
 async fn set_power_on() {
     let server = MockServer::start().await;
@@ -346,7 +348,7 @@ async fn set_power_on() {
             "model": "H6076",
             "cmd": { "name": "turn", "value": "on" }
         })))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
         .mount(&server)
         .await;
 
@@ -368,7 +370,7 @@ async fn set_power_off() {
             "model": "H6076",
             "cmd": { "name": "turn", "value": "off" }
         })))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
         .mount(&server)
         .await;
 
@@ -390,7 +392,7 @@ async fn set_brightness_valid() {
             "model": "H6076",
             "cmd": { "name": "brightness", "value": 75 }
         })))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
         .mount(&server)
         .await;
 
@@ -427,7 +429,7 @@ async fn set_color_rgb() {
             "model": "H6076",
             "cmd": { "name": "color", "value": {"r": 255, "g": 0, "b": 128} }
         })))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
         .mount(&server)
         .await;
 
@@ -452,7 +454,7 @@ async fn set_color_temp_valid() {
             "model": "H6076",
             "cmd": { "name": "colorTem", "value": 5000 }
         })))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
         .mount(&server)
         .await;
 
@@ -512,4 +514,76 @@ async fn control_command_api_error() {
         GoveeError::Api { code, .. } => assert_eq!(code, 500),
         other => panic!("expected Api error, got: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn set_brightness_boundary_zero() {
+    let server = MockServer::start().await;
+    let backend = backend_for(&server, "test-key");
+    populate_device_cache(&server, &backend).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/devices/control"))
+        .and(header("Govee-API-Key", "test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
+        .mount(&server)
+        .await;
+
+    let id = DeviceId::new("AA:BB:CC:DD:EE:FF").unwrap();
+    backend.set_brightness(&id, 0).await.unwrap();
+}
+
+#[tokio::test]
+async fn set_brightness_boundary_100() {
+    let server = MockServer::start().await;
+    let backend = backend_for(&server, "test-key");
+    populate_device_cache(&server, &backend).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/devices/control"))
+        .and(header("Govee-API-Key", "test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(CONTROL_SUCCESS, "application/json"))
+        .mount(&server)
+        .await;
+
+    let id = DeviceId::new("AA:BB:CC:DD:EE:FF").unwrap();
+    backend.set_brightness(&id, 100).await.unwrap();
+}
+
+#[tokio::test]
+async fn control_command_api_error_in_body() {
+    let error_response = r#"{"code": 400, "message": "Device offline"}"#;
+
+    let server = MockServer::start().await;
+    let backend = backend_for(&server, "test-key");
+    populate_device_cache(&server, &backend).await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/devices/control"))
+        .and(header("Govee-API-Key", "test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(error_response, "application/json"))
+        .mount(&server)
+        .await;
+
+    let id = DeviceId::new("AA:BB:CC:DD:EE:FF").unwrap();
+    let result = backend.set_power(&id, true).await;
+    match result.unwrap_err() {
+        GoveeError::Api { code, message } => {
+            assert_eq!(code, 400);
+            assert_eq!(message, "Device offline");
+        }
+        other => panic!("expected Api error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn set_color_temp_zero_rejected() {
+    let server = MockServer::start().await;
+    let backend = backend_for(&server, "test-key");
+    populate_device_cache(&server, &backend).await;
+
+    let id = DeviceId::new("AA:BB:CC:DD:EE:FF").unwrap();
+    let result = backend.set_color_temp(&id, 0).await;
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), GoveeError::InvalidConfig(_)));
 }


### PR DESCRIPTION
## Summary
- `send_control()` helper builds JSON payload with `device`, `model`, `cmd` envelope
- `set_power`: `turn` command with `"on"`/`"off"` value
- `set_brightness`: `brightness` command, validates 0–100 before sending
- `set_color`: `color` command with `{r, g, b}` object
- `set_color_temp`: `colorTem` command, passes kelvin through (device-dependent range)
- All commands reuse `check_response()` for 429/error handling and `get_model()` for device cache lookup

## Test plan
- [x] 9 wiremock tests with exact JSON body matching via `body_json`:
  - Power on/off (exact payload verified)
  - Brightness valid (75) + invalid (101 → `InvalidBrightness`)
  - Color RGB (exact `{r, g, b}` payload)
  - Color temp (5000K)
  - Device not found (empty cache)
  - Rate limited (429 + Retry-After)
  - API error (500)
- [x] All 77 tests pass, no warnings

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)