### PR TITLE
Add tracing::warn on rate limit detection

### DIFF
--- a/src/backend/cloud.rs
+++ b/src/backend/cloud.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use reqwest::Client;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::GoveeBackend;
 use crate::error::{GoveeError, Result};
@@ -169,6 +169,7 @@ impl CloudBackend {
         let status = response.status();
         if status.as_u16() == 429 {
             let retry_after_secs = parse_retry_after(&response);
+            warn!(retry_after_secs, "rate limited by Govee API");
             return Err(GoveeError::RateLimited { retry_after_secs });
         }
         if !status.is_success() {


### PR DESCRIPTION
## Summary

Adds the missing `tracing::warn!` log when a 429 response is detected. All other acceptance criteria were already implemented in prior PRs:

| Criterion | PR | Status |
|-----------|-----|--------|
| 429 → `GoveeError::RateLimited` | #59 | Done |
| `retry_after_secs` from `Retry-After` header | #59 | Done |
| wiremock tests for rate limit | #59, #60, #61 | Done (5 tests) |
| Rate limit logged via `tracing::warn` | **this PR** | Done |

The warn log includes `retry_after_secs` as a structured field — no sensitive data (API key, URLs) is logged.

## Test plan
- [x] All 84 tests pass
- [x] Existing rate limit wiremock tests cover the code path (list_devices, get_state, control)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)