### PR TITLE
Add built-in scene registry with validation

### DIFF
--- a/src/scene.rs
+++ b/src/scene.rs
@@ -80,13 +80,36 @@ pub struct SceneRegistry {
 
 impl SceneRegistry {
     /// Create a new registry populated with built-in scenes.
+    ///
+    /// Built-ins are constructed directly (no validation) since their
+    /// values are compile-time constants known to be valid.
     pub fn new() -> Self {
         let builtins = [
-            Scene::new("warm", 40, SceneColor::Temp(2700)).unwrap(),
-            Scene::new("focus", 80, SceneColor::Temp(5500)).unwrap(),
-            Scene::new("night", 10, SceneColor::Rgb(Color::new(255, 0, 0))).unwrap(),
-            Scene::new("movie", 20, SceneColor::Temp(2200)).unwrap(),
-            Scene::new("bright", 100, SceneColor::Temp(6500)).unwrap(),
+            Scene {
+                name: "warm".into(),
+                brightness: 40,
+                color: SceneColor::Temp(2700),
+            },
+            Scene {
+                name: "focus".into(),
+                brightness: 80,
+                color: SceneColor::Temp(5500),
+            },
+            Scene {
+                name: "night".into(),
+                brightness: 10,
+                color: SceneColor::Rgb(Color::new(255, 0, 0)),
+            },
+            Scene {
+                name: "movie".into(),
+                brightness: 20,
+                color: SceneColor::Temp(2200),
+            },
+            Scene {
+                name: "bright".into(),
+                brightness: 100,
+                color: SceneColor::Temp(6500),
+            },
         ];
 
         let mut scenes = HashMap::new();


### PR DESCRIPTION
## Summary
- Implement `SceneColor` enum (`Rgb`/`Temp`), `Scene` struct with validated construction (brightness 0-100, color temp 1-10000, alphanumeric/dash/underscore name), and `SceneRegistry` with case-insensitive lookup
- Populate registry with 5 built-in presets: warm, focus, night, movie, bright
- Add 10 unit tests covering all validation paths and registry operations

Closes #29

## Test plan
- [x] `cargo test` — all 143 tests pass (10 new scene tests)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no warnings
- [x] Built-in scenes present via `list()`
- [x] Case-insensitive lookup works
- [x] Invalid brightness, color temp, and name rejected with correct errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)