### PR TITLE
Fix dependabot.yml: configure cargo and github-actions ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

* Replace empty `package-ecosystem` placeholder with `cargo` and `github-actions`
  Fixes the Dependabot check failure on all PRs

## Test plan

### Automated

- [ ] Dependabot check passes on this PR

### Manual

- [ ] Verify Dependabot no longer shows as failed on PR checks